### PR TITLE
Filtering with Dropdown Select addon

### DIFF
--- a/Classes/ViewHelpers/AbstractLinkViewHelper.php
+++ b/Classes/ViewHelpers/AbstractLinkViewHelper.php
@@ -48,6 +48,7 @@ abstract class AbstractLinkViewHelper extends AbstractTagBasedViewHelper
         $this->registerUniversalTagAttributes();
         $this->registerTagAttribute('rel', 'string', 'Specifies the relationship between the current document and the linked document');
         $this->registerTagAttribute('target', 'string', 'Specifies where to open the linked document');
+        $this->registerTagAttribute('optionTag', 'bool', 'If set, the tag will be "option" for dropdown select', false, false);
     }
 
     protected function getRequest(): RequestInterface
@@ -150,9 +151,15 @@ abstract class AbstractLinkViewHelper extends AbstractTagBasedViewHelper
 
         // Render link
         if ($uri = $uriBuilder->uriFor($action, $arguments, $controller, $extensionName, $pluginName)) {
-            $this->tag->addAttribute('href', $uri);
-            $this->tag->setContent($this->renderChildren());
+            if (!$this->arguments['optionTag']) {
+                $this->tag->addAttribute('href', $uri);
+            } else {
+                $this->tag->addAttribute('value', $uri);
+                $this->tag->setTagName('option');
+            }
             $this->tag->forceClosingTag(true);
+            $this->tag->setContent($this->renderChildren());
+
             return $this->tag->render();
         }
 

--- a/Classes/ViewHelpers/Filter/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Filter/LinkViewHelper.php
@@ -83,6 +83,7 @@ final class LinkViewHelper extends AbstractFilterLinkViewHelper
 
         if (empty($this->arguments['section']) && $listUid = $this->demand->getProperty(ObjectDemandInterface::PROPERTY_CONTENT_ID)->getValue()) {
             $this->arguments['section'] = 'c' . $listUid;
+        }
         if ($this->arguments['optionTag']) {
             $this->arguments['optionTag'] = TRUE;
         }

--- a/Classes/ViewHelpers/Filter/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Filter/LinkViewHelper.php
@@ -71,6 +71,7 @@ final class LinkViewHelper extends AbstractFilterLinkViewHelper
             // Set data attributes
             if ($matches > 0) {
                 $this->tag->addAttribute(self::FILTER_ACTIVE_ATTRIBUTE, 'true');
+                $this->tag->addAttribute('selected', 'selected');
             }
         }
     }
@@ -82,6 +83,8 @@ final class LinkViewHelper extends AbstractFilterLinkViewHelper
 
         if (empty($this->arguments['section']) && $listUid = $this->demand->getProperty(ObjectDemandInterface::PROPERTY_CONTENT_ID)->getValue()) {
             $this->arguments['section'] = 'c' . $listUid;
+        if ($this->arguments['optionTag']) {
+            $this->arguments['optionTag'] = TRUE;
         }
 
         return parent::render();

--- a/Resources/Private/ExtensionDummy/{{ cookiecutter.extension_key }}/Resources/Private/Templates/Filter.html
+++ b/Resources/Private/ExtensionDummy/{{ cookiecutter.extension_key }}/Resources/Private/Templates/Filter.html
@@ -15,6 +15,16 @@
         </f:for>
     </f:if>
 
+    <f:if condition="{categories}">
+        <h2>Categories Dropdown</h2>
+        <select onChange="window.location.href=this.value">
+            <pagebased:filter.clear optionTag="1">-- Select --</pagebased:filter.clear>
+            <f:for each="{categories}" as="category">
+                <pagebased:filter.link demand="{demand}" properties="{category:category}" toggle="1" optionTag="1">{category.title}</pagebased:filter.link>
+            </f:for>
+        </select>
+    </f:if>
+
     <f:if condition="{topics}">
         <h2>Topics</h2>
         <f:for each="{topics}" as="topic">


### PR DESCRIPTION
Add an option to convert the "<a href" category, title, reset filtering to "option" tags, so that a dropdown <select> can be used instead of a normal anchor links.