### PR TITLE
[BUGFIX] Move test fixtures to separate test extension

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -67,11 +67,4 @@ return [
             ],
         ],
     ],
-    // Test fixture classes — map to pages table (only loaded in test context)
-    \Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\TestObject::class => [
-        'tableName' => \Zeroseven\Pagebased\Domain\Model\AbstractPage::TABLE_NAME,
-    ],
-    \Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\TestCategory::class => [
-        'tableName' => \Zeroseven\Pagebased\Domain\Model\AbstractPage::TABLE_NAME,
-    ],
 ];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,10 +7,6 @@ services:
     Zeroseven\Pagebased\:
         resource: '../Classes/*'
 
-    Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\:
-        resource: '../Tests/Functional/Fixtures/Classes/*'
-        public: true
-
     Zeroseven\Pagebased\Middleware\RssFeed:
         arguments:
             $cache: '@cache.pagebased_rss_feed'

--- a/Tests/Functional/Domain/Repository/AbstractObjectRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AbstractObjectRepositoryTest.php
@@ -39,6 +39,7 @@ class AbstractObjectRepositoryTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/pagebased',
+        'typo3conf/ext/pagebased/Tests/Functional/Fixtures',
     ];
 
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/Domain/Repository/AbstractObjectRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AbstractObjectRepositoryTest.php
@@ -24,7 +24,7 @@ use Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\TestObjectRepository;
  * - Default limit of 1000 when maxItems is 0
  * - Identifier constraint (_pagebased_registration = 'test_news')
  *
- * Fixtures: Tests/Functional/fixtures/Database/pages_objects.csv
+ * Fixtures: Tests/Functional/Fixtures/Database/pages_objects.csv
  *   uid 10 → category (doktype=199, _pagebased_site=1)
  *   uid 20-22 → visible objects in category 10 (_pagebased_registration=test_news)
  *   uid 23   → hidden object (hidden=1)
@@ -39,7 +39,7 @@ class AbstractObjectRepositoryTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/pagebased',
-        'typo3conf/ext/pagebased/Tests/Functional/fixtures',
+        'typo3conf/ext/pagebased/Tests/Functional/Fixtures',
     ];
 
     protected array $coreExtensionsToLoad = [
@@ -57,7 +57,7 @@ class AbstractObjectRepositoryTest extends FunctionalTestCase
         // resolve TestObjectRepository → 'test_news'.
         $this->bootstrapTestRegistration();
 
-        $this->importCSVDataSet(__DIR__ . '/../../fixtures/Database/pages_objects.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/Database/pages_objects.csv');
 
         $this->repository = $this->get(TestObjectRepository::class);
     }

--- a/Tests/Functional/Domain/Repository/AbstractObjectRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/AbstractObjectRepositoryTest.php
@@ -24,7 +24,7 @@ use Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\TestObjectRepository;
  * - Default limit of 1000 when maxItems is 0
  * - Identifier constraint (_pagebased_registration = 'test_news')
  *
- * Fixtures: Tests/Functional/Fixtures/Database/pages_objects.csv
+ * Fixtures: Tests/Functional/fixtures/Database/pages_objects.csv
  *   uid 10 → category (doktype=199, _pagebased_site=1)
  *   uid 20-22 → visible objects in category 10 (_pagebased_registration=test_news)
  *   uid 23   → hidden object (hidden=1)
@@ -39,7 +39,7 @@ class AbstractObjectRepositoryTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/pagebased',
-        'typo3conf/ext/pagebased/Tests/Functional/Fixtures',
+        'typo3conf/ext/pagebased/Tests/Functional/fixtures',
     ];
 
     protected array $coreExtensionsToLoad = [
@@ -57,7 +57,7 @@ class AbstractObjectRepositoryTest extends FunctionalTestCase
         // resolve TestObjectRepository → 'test_news'.
         $this->bootstrapTestRegistration();
 
-        $this->importCSVDataSet(__DIR__ . '/../../Fixtures/Database/pages_objects.csv');
+        $this->importCSVDataSet(__DIR__ . '/../../fixtures/Database/pages_objects.csv');
 
         $this->repository = $this->get(TestObjectRepository::class);
     }

--- a/Tests/Functional/Fixtures/Configuration/Extbase/Persistence/Classes.php
+++ b/Tests/Functional/Fixtures/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    \Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\TestObject::class => [
+        'tableName' => \Zeroseven\Pagebased\Domain\Model\AbstractPage::TABLE_NAME,
+    ],
+    \Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\TestCategory::class => [
+        'tableName' => \Zeroseven\Pagebased\Domain\Model\AbstractPage::TABLE_NAME,
+    ],
+];

--- a/Tests/Functional/Fixtures/Configuration/Services.yaml
+++ b/Tests/Functional/Fixtures/Configuration/Services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: true
+
+    Zeroseven\Pagebased\Tests\Functional\Fixtures\Classes\:
+        resource: '../Classes/*'

--- a/Tests/Functional/Fixtures/ext_emconf.php
+++ b/Tests/Functional/Fixtures/ext_emconf.php
@@ -11,6 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-12.99.99',
+            'pagebased' => '',
         ],
     ],
 ];

--- a/Tests/Functional/Fixtures/ext_emconf.php
+++ b/Tests/Functional/Fixtures/ext_emconf.php
@@ -11,7 +11,6 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '12.4.0-12.99.99',
-            'pagebased' => '',
         ],
     ],
 ];

--- a/Tests/Functional/Fixtures/ext_emconf.php
+++ b/Tests/Functional/Fixtures/ext_emconf.php
@@ -1,0 +1,16 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Pagebased Test Fixtures',
+    'description' => 'Test fixtures for pagebased functional tests',
+    'category' => 'misc',
+    'version' => '1.0.0',
+    'state' => 'stable',
+    'author' => 'zeroseven',
+    'author_email' => 'typo3@zeroseven.de',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '12.4.0-12.99.99',
+        ],
+    ],
+];

--- a/Tests/Functional/Performance/RepositoryPerformanceTest.php
+++ b/Tests/Functional/Performance/RepositoryPerformanceTest.php
@@ -31,7 +31,7 @@ final class RepositoryPerformanceTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/pagebased',
-        'typo3conf/ext/pagebased/Tests/Functional/pagebased_test_fixtures',
+        'typo3conf/ext/pagebased/Tests/Functional/Fixtures',
     ];
 
     protected array $configurationToUseInTestInstance = [
@@ -51,7 +51,7 @@ final class RepositoryPerformanceTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->importCSVDataSet(__DIR__ . '/../pagebased_test_fixtures/Database/pages_many_objects.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Database/pages_many_objects.csv');
         $this->bootstrapTestRegistration();
         $this->repository = $this->get(TestObjectRepository::class);
         QueryCountingMiddleware::reset();

--- a/Tests/Functional/Performance/RepositoryPerformanceTest.php
+++ b/Tests/Functional/Performance/RepositoryPerformanceTest.php
@@ -29,7 +29,10 @@ use Zeroseven\Pagebased\Tests\Functional\Fixtures\Middleware\QueryCountingMiddle
  */
 final class RepositoryPerformanceTest extends FunctionalTestCase
 {
-    protected array $testExtensionsToLoad = ['typo3conf/ext/pagebased'];
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/pagebased',
+        'typo3conf/ext/pagebased/Tests/Functional/Fixtures',
+    ];
 
     protected array $configurationToUseInTestInstance = [
         'DB' => [

--- a/Tests/Functional/Performance/RepositoryPerformanceTest.php
+++ b/Tests/Functional/Performance/RepositoryPerformanceTest.php
@@ -31,7 +31,7 @@ final class RepositoryPerformanceTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/pagebased',
-        'typo3conf/ext/pagebased/Tests/Functional/Fixtures',
+        'typo3conf/ext/pagebased/Tests/Functional/pagebased_test_fixtures',
     ];
 
     protected array $configurationToUseInTestInstance = [
@@ -51,7 +51,7 @@ final class RepositoryPerformanceTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Database/pages_many_objects.csv');
+        $this->importCSVDataSet(__DIR__ . '/../pagebased_test_fixtures/Database/pages_many_objects.csv');
         $this->bootstrapTestRegistration();
         $this->repository = $this->get(TestObjectRepository::class);
         QueryCountingMiddleware::reset();


### PR DESCRIPTION
* Remove test fixture services from global Configuration/Services.yaml
* Remove test fixture persistence mappings from global Extbase config
* Structure test fixtures as mini-extension in Tests/Functional/Fixtures/
* Update tests to load fixtures extension via testExtensionsToLoad

This fixes crashes when the extension is used as a dependency, where autoload-dev classes are not available but were being referenced in global configuration files.